### PR TITLE
fix: update axios to ^1.15.0 - resolve CVE-2025-62718 (Critical SSRF)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "testURL": "http://localhost/"
   },
   "dependencies": {
-    "axios": "^0.21.1",
+    "axios": "^1.15.0",
     "git-remote-origin-url": "^3.1.0",
     "git-url-parse": "^11.4.4",
     "simple-git": "^2.40.0"


### PR DESCRIPTION
## 🔒 Security Fix: CVE-2025-62718\n\n### Vulnerabilidad\n**Axios NO_PROXY Hostname Normalization Bypass Leads to SSRF**\n- **Severidad:** Crítica (CVSS 9.9)\n- **CVE:** CVE-2025-62718\n\n### Cambios\n- Actualizado `axios` de `^0.21.1` a `^1.15.0` en `package.json`\n\n### ⚠️ Acción requerida\nDespués de hacer merge, ejecutar localmente:\n```bash\nnpm install\n```\nPara regenerar el `package-lock.json` con la versión actualizada de axios.\n\n### Descripción\nVersiones anteriores a 1.15.0 de Axios no normalizaban correctamente los hostnames al evaluar las reglas `NO_PROXY`, permitiendo ataques SSRF.